### PR TITLE
Update multi sig example

### DIFF
--- a/code/multisig_p2wsh_2_4.js
+++ b/code/multisig_p2wsh_2_4.js
@@ -31,7 +31,7 @@ const psbt = new bitcoin.Psbt({network})
     index: TX_VOUT,
     witnessScript: p2wsh.redeem.output,
     witnessUtxo: {
-      script: Buffer.from('0020' + bitcoin.crypto.sha256(p2ms.output).toString('hex'), 'hex'),
+      script: p2wsh.output,
       value: 1e8,
     }
   })


### PR DESCRIPTION
`payment.output` for a p2wsh is same as `PUSH_BYTES 32 <witnessScript>`